### PR TITLE
Remove optimizeLegibility

### DIFF
--- a/css/houzz-icon-font.css
+++ b/css/houzz-icon-font.css
@@ -32,7 +32,6 @@
   font-variant: normal;
   line-height: 1;
   text-decoration: inherit;
-  text-rendering: optimizeLegibility;
   text-transform: none;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
CSS text-rendering: optimizeLegibility causes performance issues on some browsers. No kerning or rendering issues if removed.